### PR TITLE
Enhance usability of ModelZoo-PIDNet

### DIFF
--- a/auto_process.py
+++ b/auto_process.py
@@ -345,3 +345,22 @@ if __name__ == "__main__":
             head=config.MODEL.NAME + '_head_fx.pt')
 
     logger.info("Fine-tuning step end.")
+
+    """ 
+        Export PIDNet model to onnx
+    """
+    logger.info("Export model to onnx format step start.")
+
+    model_model = torch.load(os.path.join(final_output_dir, 'best_model_model.pt'), map_location='cpu')
+    model_head = torch.load(os.path.join(final_output_dir, 'best_model_head.pt'), map_location='cpu')
+ 
+    model_head.netspresso = True
+    model_head.export = True
+    combined_model = torch.nn.Sequential(model_model, model_head)
+
+    dummy_input = torch.randn(1, 3, 1024, 1024)
+    torch.onnx.export(combined_model, dummy_input, COMPRESSED_MODEL_NAME + '.onnx', 
+                      verbose=True, input_names=['input'], output_names=['output'], opset_version=12)
+    logger.info(f'=> saving model to {COMPRESSED_MODEL_NAME}.onnx')
+
+    logger.info("Export model to onnx format step end.")

--- a/auto_process.py
+++ b/auto_process.py
@@ -60,7 +60,7 @@ def parse_args():
     parser.add_argument(
         "--compression_ratio",
         type=int,
-        default=0.5
+        default=0.3
     )
     parser.add_argument(
         "-w",

--- a/auto_process.py
+++ b/auto_process.py
@@ -172,7 +172,7 @@ def trainer(args, config, logger, final_output_dir, tb_log_dir, model, head):
         params = [{'params': list(params_dict.values()), 'lr': config.TRAIN.LR}]
 
         optimizer = torch.optim.SGD(params,
-                                lr=config.TRAIN.LR,
+                                lr=config.TRAIN.LR * 0.1,
                                 momentum=config.TRAIN.MOMENTUM,
                                 weight_decay=config.TRAIN.WD,
                                 nesterov=config.TRAIN.NESTEROV,

--- a/auto_process.py
+++ b/auto_process.py
@@ -358,7 +358,7 @@ if __name__ == "__main__":
     combined_model = torch.nn.Sequential(model_model, model_head)
     combined_model.eval()
 
-    dummy_input = torch.randn(1, 3, 1024, 1024)
+    dummy_input = torch.randn(1, 3, config.TEST.IMAGE_SIZE[0], config.TEST.IMAGE_SIZE[1])
     torch.onnx.export(combined_model, dummy_input, COMPRESSED_MODEL_NAME + '.onnx', 
                       verbose=True, input_names=['input'], output_names=['output'], opset_version=12)
     logger.info(f'=> saving model to {COMPRESSED_MODEL_NAME}.onnx')

--- a/auto_process.py
+++ b/auto_process.py
@@ -1,0 +1,95 @@
+import argparse
+import os
+
+import torch
+
+import models
+from configs import config
+from configs import update_config
+from utils.utils import create_logger
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Train segmentation network')
+
+    """
+        Common arguments
+    """
+    parser.add_argument('--cfg',
+                        help='experiment configure file name',
+                        default="configs/cityscapes/pidnet_small_cityscapes.yaml",
+                        type=str
+    )
+    parser.add_argument('opts',
+                        help="Modify config options using the command-line",
+                        default=None,
+                        nargs=argparse.REMAINDER
+    )
+
+
+    args = parser.parse_args()
+    update_config(config, args)
+
+    return args
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    logger, final_output_dir, _ = create_logger(
+        config, args.cfg, 'test')
+    
+    """ 
+        Convert PIDNet model to fx 
+    """
+    logger.info("PIDNet to fx graph start.")
+    # build model
+    model_model, model_head = models.pidnet.get_netspresso_model(config, imgnet_pretrained=True)
+
+    if config.TEST.MODEL_FILE:
+        model_state_file = config.TEST.MODEL_FILE
+    else:
+        model_state_file = os.path.join(final_output_dir, 'best.pt')
+   
+    logger.info('=> loading model from {}'.format(model_state_file))
+        
+    pretrained_dict = torch.load(model_state_file)
+    if 'state_dict' in pretrained_dict:
+        pretrained_dict = pretrained_dict['state_dict']
+        
+    #model_model    
+    model_model_dict = model_model.state_dict()
+    pretrained_dict = {k[6:]: v for k, v in pretrained_dict.items()
+                        if k[6:] in model_model_dict.keys()}
+    for k, _ in pretrained_dict.items():
+        logger.info(
+            '=> loading {} from pretrained model'.format(k))
+    model_model_dict.update(pretrained_dict)
+    
+    model_model.load_state_dict(model_model_dict)
+    
+    #model_head
+    model_head_dict = model_head.state_dict()
+    pretrained_dict = {k[6:]: v for k, v in pretrained_dict.items()
+                        if k[6:] in model_head_dict.keys()}
+    for k, _ in pretrained_dict.items():
+        logger.info(
+            '=> loading {} from pretrained model'.format(k))
+    model_head_dict.update(pretrained_dict)
+    
+    model_head.load_state_dict(model_head_dict)
+    
+    import torch.fx as fx
+    
+    #save model_model
+    model_model.train()
+    _graph = fx.Tracer().trace(model_model)
+    traced_model = fx.GraphModule(model_model, _graph)
+    torch.save(traced_model, "./model_modelfx.pt")
+    logger.info('=> saving model_model torchfx to ./model_modelfx.pt')
+    
+    #save model_head
+    model_head.train()
+    torch.save(model_head, "./model_headfx.pt")
+    logger.info('=> saving model_head torchfx to ./model_headfx.pt')
+
+    logger.info("PIDNet to fx graph end.")

--- a/auto_process.py
+++ b/auto_process.py
@@ -1,13 +1,27 @@
 import argparse
 import os
+import pprint
+import sys
+
+import logging
+import timeit
+
+import numpy as np
 
 import torch
+import torch.nn as nn
+import torch.backends.cudnn as cudnn
+import torch.optim
+from tensorboardX import SummaryWriter
 from netspresso.compressor import ModelCompressor, Task, Framework
 
 import models
+import datasets
 from configs import config
 from configs import update_config
-from utils.utils import create_logger
+from utils.criterion import CrossEntropy, OhemCrossEntropy, BondaryLoss
+from utils.function import train, validate
+from utils.utils import create_logger, FullModel
 
 
 def parse_args():
@@ -71,10 +85,166 @@ def parse_args():
 
     return args
 
+def trainer(args, config, logger, final_output_dir, tb_log_dir, model, head):
+    logger.info(pprint.pformat(args))
+    logger.info(config)
+
+    writer_dict = {
+        'writer': SummaryWriter(tb_log_dir),
+        'train_global_steps': 0,
+        'valid_global_steps': 0,
+    }
+
+    # cudnn related setting
+    cudnn.benchmark = config.CUDNN.BENCHMARK
+    cudnn.deterministic = config.CUDNN.DETERMINISTIC
+    cudnn.enabled = config.CUDNN.ENABLED
+    gpus = list(config.GPUS)
+
+    model_model = torch.load(model)
+    model_head = torch.load(head)
+
+    model = nn.Sequential(
+        model_model,
+        model_head
+    )
+ 
+    batch_size = config.TRAIN.BATCH_SIZE_PER_GPU * len(gpus)
+    # prepare data
+    crop_size = (config.TRAIN.IMAGE_SIZE[1], config.TRAIN.IMAGE_SIZE[0])
+    train_dataset = eval('datasets.'+config.DATASET.DATASET)(
+                        root=config.DATASET.ROOT,
+                        list_path=config.DATASET.TRAIN_SET,
+                        num_classes=config.DATASET.NUM_CLASSES,
+                        multi_scale=config.TRAIN.MULTI_SCALE,
+                        flip=config.TRAIN.FLIP,
+                        ignore_label=config.TRAIN.IGNORE_LABEL,
+                        base_size=config.TRAIN.BASE_SIZE,
+                        crop_size=crop_size,
+                        scale_factor=config.TRAIN.SCALE_FACTOR)
+
+    trainloader = torch.utils.data.DataLoader(
+        train_dataset,
+        batch_size=batch_size,
+        shuffle=config.TRAIN.SHUFFLE,
+        num_workers=config.WORKERS,
+        pin_memory=False,
+        drop_last=True)
+
+
+    test_size = (config.TEST.IMAGE_SIZE[1], config.TEST.IMAGE_SIZE[0])
+    test_dataset = eval('datasets.'+config.DATASET.DATASET)(
+                        root=config.DATASET.ROOT,
+                        list_path=config.DATASET.TEST_SET,
+                        num_classes=config.DATASET.NUM_CLASSES,
+                        multi_scale=False,
+                        flip=False,
+                        ignore_label=config.TRAIN.IGNORE_LABEL,
+                        base_size=config.TEST.BASE_SIZE,
+                        crop_size=test_size)
+
+    testloader = torch.utils.data.DataLoader(
+        test_dataset,
+        batch_size=config.TEST.BATCH_SIZE_PER_GPU * len(gpus),
+        shuffle=False,
+        num_workers=config.WORKERS,
+        pin_memory=False)
+
+    # criterion
+    if config.LOSS.USE_OHEM:
+        sem_criterion = OhemCrossEntropy(ignore_label=config.TRAIN.IGNORE_LABEL,
+                                        thres=config.LOSS.OHEMTHRES,
+                                        min_kept=config.LOSS.OHEMKEEP,
+                                        weight=train_dataset.class_weights)
+    else:
+        sem_criterion = CrossEntropy(ignore_label=config.TRAIN.IGNORE_LABEL,
+                                    weight=train_dataset.class_weights)
+
+    bd_criterion = BondaryLoss()
+    
+    model = FullModel(model, sem_criterion, bd_criterion)
+    model = nn.DataParallel(model, device_ids=gpus).cuda()
+
+    # optimizer
+    if config.TRAIN.OPTIMIZER == 'sgd':
+        params_dict = dict(model.named_parameters())
+        params = [{'params': list(params_dict.values()), 'lr': config.TRAIN.LR}]
+
+        optimizer = torch.optim.SGD(params,
+                                lr=config.TRAIN.LR,
+                                momentum=config.TRAIN.MOMENTUM,
+                                weight_decay=config.TRAIN.WD,
+                                nesterov=config.TRAIN.NESTEROV,
+                                )
+    else:
+        raise ValueError('Only Support SGD optimizer')
+
+    epoch_iters = int(train_dataset.__len__() / config.TRAIN.BATCH_SIZE_PER_GPU / len(gpus))
+        
+    best_mIoU = 0
+    last_epoch = 0
+    flag_rm = config.TRAIN.RESUME
+    if config.TRAIN.RESUME and not args.netspresso:
+        model_state_file = os.path.join(final_output_dir, 'checkpoint.pth.tar')
+        if os.path.isfile(model_state_file):
+            checkpoint = torch.load(model_state_file, map_location={'cuda:0': 'cpu'})
+            best_mIoU = checkpoint['best_mIoU']
+            last_epoch = checkpoint['epoch']
+            dct = checkpoint['state_dict']
+            
+            model.module.model.load_state_dict({k.replace('model.', ''): v for k, v in dct.items() if k.startswith('model.')})
+            optimizer.load_state_dict(checkpoint['optimizer'])
+            logger.info("=> loaded checkpoint (epoch {})".format(checkpoint['epoch']))
+
+    start = timeit.default_timer()
+    end_epoch = config.TRAIN.END_EPOCH
+    num_iters = config.TRAIN.END_EPOCH * epoch_iters
+    real_end = 120+1 if 'camvid' in config.DATASET.TRAIN_SET else end_epoch
+    
+    for epoch in range(last_epoch, real_end):
+
+        current_trainloader = trainloader
+        if current_trainloader.sampler is not None and hasattr(current_trainloader.sampler, 'set_epoch'):
+            current_trainloader.sampler.set_epoch(epoch)
+
+        train(config, epoch, config.TRAIN.END_EPOCH, 
+                  epoch_iters, config.TRAIN.LR, num_iters,
+                  trainloader, optimizer, model, writer_dict)
+
+        if flag_rm == 1 or (epoch % 5 == 0 and epoch < real_end - 100) or (epoch >= real_end - 100):
+            valid_loss, mean_IoU, IoU_array = validate(config, 
+                        testloader, model, writer_dict)
+        if flag_rm == 1:
+            flag_rm = 0
+            
+        #Netspresso_ 분리해서 저장하는 코드 작성
+        logger.info('=> saving model_model to {}'.format(final_output_dir + 'retrain_model_model.pt'))
+        torch.save(model_model, os.path.join(final_output_dir,'retrain_model_model.pt'))
+        logger.info('=> saving model_head to {}'.format(final_output_dir + 'retrain_model_head.pt'))
+        torch.save(model_head, os.path.join(final_output_dir,'retrain_model_head.pt'))
+        if mean_IoU > best_mIoU:
+            best_mIoU = mean_IoU
+            torch.save(model_model, os.path.join(final_output_dir, 'best_model_model.pt'))
+            torch.save(model_head, os.path.join(final_output_dir, 'best_model_head.pt'))
+        msg = 'Loss: {:.3f}, MeanIU: {: 4.4f}, Best_mIoU: {: 4.4f}'.format(
+                    valid_loss, mean_IoU, best_mIoU)
+
+        logging.info(msg)
+        logging.info(IoU_array)
+        
+    torch.save(model_model, os.path.join(final_output_dir, 'final_model_model.pt'))
+    torch.save(model_head, os.path.join(final_output_dir, 'final_model_head.pt'))
+
+    writer_dict['writer'].close()
+    end = timeit.default_timer()
+    logger.info('Hours: %d' % np.int((end-start)/3600))
+    logger.info('Done')
+
+
 if __name__ == "__main__":
     args = parse_args()
 
-    logger, final_output_dir, _ = create_logger(
+    logger, final_output_dir, tb_log_dir = create_logger(
         config, args.cfg, 'test')
     
     """ 
@@ -164,3 +334,14 @@ if __name__ == "__main__":
     )
 
     logger.info("Compression step end.")
+
+    """ 
+        Retrain PIDNet model 
+    """
+    logger.info("Fine-tuning step start.")
+
+    trainer(args, config, logger, final_output_dir, tb_log_dir, 
+            model=COMPRESSED_MODEL_NAME + '.pt', 
+            head=config.MODEL.NAME + '_head_fx.pt')
+
+    logger.info("Fine-tuning step end.")

--- a/auto_process.py
+++ b/auto_process.py
@@ -9,6 +9,7 @@ import timeit
 import numpy as np
 
 import torch
+import torch.fx as fx
 import torch.nn as nn
 import torch.backends.cudnn as cudnn
 import torch.optim
@@ -283,8 +284,6 @@ if __name__ == "__main__":
     
     model_head.load_state_dict(model_head_dict)
     
-    import torch.fx as fx
-    
     #save model_model
     model_model.train()
     _graph = fx.Tracer().trace(model_model)
@@ -307,7 +306,7 @@ if __name__ == "__main__":
     compressor = ModelCompressor(email=args.np_email, password=args.np_password)
 
     UPLOAD_MODEL_NAME = config.MODEL.NAME
-    TASK = Task.OBJECT_DETECTION
+    TASK = Task.SEMANTIC_SEGMENTATION
     FRAMEWORK = Framework.PYTORCH
     UPLOAD_MODEL_PATH = config.MODEL.NAME + '_fx.pt'
     INPUT_SHAPES = [{"batch": 1, "channel": 3, "dimension": config.TRAIN.IMAGE_SIZE}]
@@ -357,6 +356,7 @@ if __name__ == "__main__":
     model_head.netspresso = True
     model_head.export = True
     combined_model = torch.nn.Sequential(model_model, model_head)
+    combined_model.eval()
 
     dummy_input = torch.randn(1, 3, 1024, 1024)
     torch.onnx.export(combined_model, dummy_input, COMPRESSED_MODEL_NAME + '.onnx', 


### PR DESCRIPTION
Slack link: https://nota-workspace.slack.com/archives/C040F65LSAJ/p1692766946904609
Notion link: https://www.notion.so/notaai/PIDNet-023cd19818d74d3caccf5d2dd2673f08?pvs=4

목적
---
ModelZoo에서 세분화된 기능을 하나로 합쳐서 하나의 파일만 실행하면 경량화 → 재학습 → onnx export까지 되어 LaunchX 사용 가능하게 한다.

변경 사항
---
- auto_process.py 파일을 생성했습니다. fx 변환, 경량화, 재학습, onnx 변환 이라는 단계를 거치며, 이를 위해 다음과 같은 argument를 받습니다.
  - cofig_path (기본값으로 `configs/cityscapes/pidnet_small_cityscapes.yaml` 로 설정되어 있습니다)
  - 모델 weight path
  - NetsPresso 이메일 계정
  - NetsPresso 계정 비밀번호
- 기존 코드의 수정을 막기 위해, 기존 코드들을 가져와 순서대로 작동하도록 구성했습니다.
- 중간에 발생하는 fx와 onnx 파일은 `root` 디렉토리에 생성되며, 재학습에서 발생하는 파일들은 `output/{dataset_name}/{model_name}_{dataset_name}` 에 생성됩니다.
- 테스트
  - `python auto_process.py -w {pretrained_path} --np_email {email} --np_password {password}`
  - [cityscapes](https://www.cityscapes-dataset.com/) 데이터셋을 받아 실험했습니다.
  - [PIDNet](https://github.com/XuJiacong/PIDNet) 레포로부터 [cityscapes pretrained](https://drive.google.com/file/d/1VcF3NXLQvz2qE3LXttpxWQSdxTbATslO/view?usp=sharing)를 받아 사용했습니다.
