### PR TITLE
[HOTFIX] Handle index out of range error.

### DIFF
--- a/utils/criterion.py
+++ b/utils/criterion.py
@@ -70,7 +70,10 @@ class OhemCrossEntropy(nn.Module):
         tmp_target[tmp_target == self.ignore_label] = 0
         pred = pred.gather(1, tmp_target.unsqueeze(1))
         pred, ind = pred.contiguous().view(-1,)[mask].contiguous().sort()
-        min_value = pred[min(self.min_kept, pred.numel() - 1)]
+        if pred.numel() > 0:
+            min_value = pred[min(self.min_kept, pred.numel() - 1)]
+        else:
+            return score.new_tensor(0.0)
         threshold = max(min_value, self.thresh)
 
         pixel_losses = pixel_losses[mask][ind]


### PR DESCRIPTION
Potential Error during training as follows:

File "ModelZoo-PIDNet/tools/../utils/criterion.py", line 73, in _ohem_forward
    min_value = pred[min(self.min_kept, pred.numel() - 1)]
IndexError: index -1 is out of bounds for dimension 0 with size 0